### PR TITLE
CM-110: export necessary actions to create benefit package page for groups

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -133,7 +133,7 @@ export function downloadGroups(params) {
 export function downloadIndividuals(params) {
   const payload = `
     {
-      individualsExport${!!params && params.length ? `(${params.join(',')})` : ''}
+      individualExport${!!params && params.length ? `(${params.join(',')})` : ''}
     }`;
   return graphql(payload, ACTION_TYPE.INDIVIDUAL_EXPORT);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import GroupsPage from './pages/GroupsPage';
 import GroupPage from './pages/GroupPage';
 import { IndividualsListTabLabel, IndividualsListTabPanel } from './components/IndividualsListTab';
 import IndividualSearcher from './components/IndividualSearcher';
+import { fetchIndividuals } from './actions';
 
 const ROUTE_INDIVIDUALS = 'individuals';
 const ROUTE_INDIVIDUAL = 'individuals/individual';
@@ -35,6 +36,7 @@ const DEFAULT_CONFIG = {
     { key: 'individual.route.individual', ref: ROUTE_INDIVIDUAL },
     { key: 'individual.route.group', ref: ROUTE_GROUP },
     { key: 'individual.IndividualSearcher', ref: IndividualSearcher },
+    { key: 'individual.actions.fetchIndividuals', ref: fetchIndividuals },
   ],
   'individual.TabPanel.label': [
     IndividualsListTabLabel,

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import GroupsPage from './pages/GroupsPage';
 import GroupPage from './pages/GroupPage';
 import { IndividualsListTabLabel, IndividualsListTabPanel } from './components/IndividualsListTab';
 import IndividualSearcher from './components/IndividualSearcher';
-import { fetchIndividuals } from './actions';
+import { downloadIndividuals, fetchIndividuals } from './actions';
 
 const ROUTE_INDIVIDUALS = 'individuals';
 const ROUTE_INDIVIDUAL = 'individuals/individual';
@@ -37,6 +37,7 @@ const DEFAULT_CONFIG = {
     { key: 'individual.route.group', ref: ROUTE_GROUP },
     { key: 'individual.IndividualSearcher', ref: IndividualSearcher },
     { key: 'individual.actions.fetchIndividuals', ref: fetchIndividuals },
+    { key: 'individual.actions.downloadIndividuals', ref: downloadIndividuals },
   ],
   'individual.TabPanel.label': [
     IndividualsListTabLabel,


### PR DESCRIPTION
[RELATED PR](https://github.com/openimis/openimis-fe-social_protection_js/pull/20)

[CM-110](https://openimis.atlassian.net/browse/CM-110)

Changes:
- Create a ref with _fetchIndividuals_ and _downloadIndividuals_ to reuse it in fe-social_protection module.

[CM-110]: https://openimis.atlassian.net/browse/CM-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ