### PR TITLE
CM-134: use id in mutation labels to avoid mutation errors

### DIFF
--- a/src/components/GroupIndividualSearcher.js
+++ b/src/components/GroupIndividualSearcher.js
@@ -151,8 +151,7 @@ function GroupIndividualSearcher({
       updateGroupIndividual(
         editedGroupIndividual,
         formatMessageWithValues(intl, 'individual', 'groupIndividual.update.mutationLabel', {
-          firstName: editedGroupIndividual.individual.firstName,
-          lastName: editedGroupIndividual.individual.lastName,
+          id: editedGroupIndividual?.individual?.id,
         }),
       );
     }

--- a/src/components/IndividualSearcher.js
+++ b/src/components/IndividualSearcher.js
@@ -86,8 +86,7 @@ function IndividualSearcher({
       deleteIndividual(
         individualToDelete,
         formatMessageWithValues(intl, 'individual', 'individual.delete.mutationLabel', {
-          firstName: individualToDelete.firstName,
-          lastName: individualToDelete.lastName,
+          id: individualToDelete?.id,
         }),
       );
       setDeletedIndividualUuids([...deletedIndividualUuids, individualToDelete.id]);

--- a/src/pages/IndividualPage.js
+++ b/src/pages/IndividualPage.js
@@ -106,8 +106,7 @@ function IndividualPage({
     updateIndividual(
       editedIndividual,
       formatMessageWithValues(intl, 'individual', 'individual.update.mutationLabel', {
-        firstName: individual?.firstName,
-        lastName: individual?.lastName,
+        id: individual?.id,
       }),
     );
   };
@@ -115,8 +114,7 @@ function IndividualPage({
   const deleteIndividualCallback = () => deleteIndividual(
     individual,
     formatMessageWithValues(intl, 'individual', 'individual.delete.mutationLabel', {
-      firstName: individual?.firstName,
-      lastName: individual?.lastName,
+      id: individual?.id,
     }),
   );
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -25,11 +25,11 @@
         "title": "Delete {firstName} {lastName}?",
         "message": "Deleting data does not mean erasing it from OpenIMIS database. The data will only be deactivated from the viewed list."
       },
-      "mutationLabel": "Delete Individual {firstName} {lastName}"
+      "mutationLabel": "Delete Individual {id}"
     },
     "update": {
       "label": "Update Individual",
-      "mutationLabel":"Update Individual {firstName} {lastName}"
+      "mutationLabel":"Update Individual {id}"
     },
     "saveButton.tooltip.enabled": "Save changes",
     "saveButton.tooltip.disabled": "Please fill General Information fields first",
@@ -96,7 +96,7 @@
     },
     "update": {
       "label": "Update Individual",
-      "mutationLabel":"Update Individual {firstName} {lastName}"
+      "mutationLabel":"Update Individual {id}"
     },
     "groupIndividualRolePicker.HEAD":  "HEAD",
     "groupIndividualRolePicker.RECIPIENT": "RECIPIENT",


### PR DESCRIPTION
[CM-134](https://openimis.atlassian.net/browse/CM-134)

[RELATED BE PR
](https://github.com/openimis/openimis-be-individual_py/pull/15)

Changes:
- Use ID instead of first/last name in mutation labels. It ensures shorter and more manageable labels without exceeding the maximum length, so the issue with saving/editing is gone.

[CM-134]: https://openimis.atlassian.net/browse/CM-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ