### PR TITLE
OP-2329: blocking adding individual when new group is created, allow on edit mode

### DIFF
--- a/src/pages/GroupPage.js
+++ b/src/pages/GroupPage.js
@@ -165,12 +165,13 @@ function GroupPage({
       doIt: openDeleteGroupConfirmDialog,
       icon: <DeleteIcon />,
       tooltip: formatMessage(intl, 'individual', 'deleteButtonTooltip'),
-    }, {
+    },
+    groupUuid && {
       doIt: setIsAddIndividualToGroupModalOpen,
       icon: <AddIcon />,
       tooltip: formatMessage(intl, 'individual', 'addButtonTooltip'),
     },
-  ];
+  ].filter(Boolean);
 
   const onAddIndividualConfirm = (individualToBeChanged) => {
     const addIndividualToGroup = {
@@ -192,12 +193,14 @@ function GroupPage({
   return (
     rights.includes(RIGHT_GROUP_SEARCH) && (
     <div className={readOnly ? classes.lockedPage : classes.page}>
-      <IndividualAddToGroupDialog
-        confirmState={isAddIndividualToGroupModalOpen}
-        onClose={() => setIsAddIndividualToGroupModalOpen(false)}
-        onConfirm={onAddIndividualConfirm}
-        setEditedGroupIndividual={setEditedGroupIndividual}
-      />
+      {groupUuid && (
+        <IndividualAddToGroupDialog
+          confirmState={isAddIndividualToGroupModalOpen}
+          onClose={() => setIsAddIndividualToGroupModalOpen(false)}
+          onConfirm={onAddIndividualConfirm}
+          setEditedGroupIndividual={setEditedGroupIndividual}
+        />
+      )}
       <Helmet title={formatMessageWithValues(intl, 'group', 'pageTitle', titleParams(group))} />
       <Form
         module="group"


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2329

The flow should be: 
a) Add new group 
- only adding group data like code and location

b) Edit group
- you can delete whole group
- you can delete member 
- you can add new member

Therefore the change is to disable '+' icon responsible for adding new individuals to the group while adding new group, This feature is only for EDIT mode. 

1. ADD mode
![Screenshot from 2025-02-13 15-46-21](https://github.com/user-attachments/assets/a2aeefd2-67d2-432b-8e79-19089394135e)

2. EDIT mode
![Screenshot from 2025-02-13 15-46-40](https://github.com/user-attachments/assets/c5f0e8b2-01c3-4827-acc0-c525b2d6b2a5)

